### PR TITLE
test: add edge case tests for zero-length and single-element vectors …

### DIFF
--- a/tests/testthat/test-buffer.R
+++ b/tests/testthat/test-buffer.R
@@ -220,3 +220,41 @@ test_that("buffer logical type works", {
     expect_equal(buf[c(2, 4, 6, 8, 10)], rep(FALSE, 5))
     buffer_close(buf)
 })
+
+test_that("buffer handles single-element dimension", {
+    # Single-element double buffer
+    buf <- buffer("double", dim = 1)
+    expect_equal(buf$n, 1)
+    expect_equal(length(buf), 1)
+    expect_equal(buf[], 0)
+
+    buf[1] <- 42
+    expect_equal(buf[1], 42)
+    expect_equal(buf[], 42)
+    buffer_close(buf)
+
+    # Single-element integer buffer
+    buf <- buffer("integer", dim = 1)
+    buf[1] <- 99L
+    expect_equal(buf[1], 99L)
+    buffer_close(buf)
+
+    # Single-element logical buffer
+    buf <- buffer("logical", dim = 1)
+    expect_equal(buf[1], FALSE)
+    buf[1] <- TRUE
+    expect_equal(buf[1], TRUE)
+    buffer_close(buf)
+})
+
+test_that("buffer handles 1x1 matrix dimension", {
+    buf <- buffer("double", dim = c(1, 1))
+    expect_equal(dim(buf), c(1, 1))
+    expect_equal(length(buf), 1)
+
+    buf[1, 1] <- 42
+    expect_equal(buf[1, 1], 42)
+    expect_equal(buf[], matrix(42, 1, 1))
+
+    buffer_close(buf)
+})

--- a/tests/testthat/test-share.R
+++ b/tests/testthat/test-share.R
@@ -257,6 +257,113 @@ test_that("share handles empty vectors", {
     close(shared)
 })
 
+test_that("share handles zero-length vectors of all types", {
+    # Double
+    x <- double(0)
+    shared <- share(x)
+    recovered <- fetch(shared)
+    expect_identical(x, recovered)
+    close(shared)
+
+    # Logical
+    x <- logical(0)
+    shared <- share(x)
+    recovered <- fetch(shared)
+    expect_identical(x, recovered)
+    close(shared)
+
+    # Character
+    x <- character(0)
+    shared <- share(x)
+    recovered <- fetch(shared)
+    expect_identical(x, recovered)
+    close(shared)
+
+    # Raw
+    x <- raw(0)
+    shared <- share(x)
+    recovered <- fetch(shared)
+    expect_identical(x, recovered)
+    close(shared)
+})
+
+test_that("share handles single-element vectors", {
+    # Single integer
+    x <- 1L
+    shared <- share(x)
+    recovered <- fetch(shared)
+    expect_identical(x, recovered)
+    close(shared)
+
+    # Single double
+    x <- 3.14
+    shared <- share(x)
+    recovered <- fetch(shared)
+    expect_equal(x, recovered)
+    close(shared)
+
+    # Single character
+    x <- "hello"
+    shared <- share(x)
+    recovered <- fetch(shared)
+    expect_identical(x, recovered)
+    close(shared)
+
+    # Single logical
+    x <- TRUE
+    shared <- share(x)
+    recovered <- fetch(shared)
+    expect_identical(x, recovered)
+    close(shared)
+
+    # Single NA
+    x <- NA
+    shared <- share(x)
+    recovered <- fetch(shared)
+    expect_identical(x, recovered)
+    close(shared)
+})
+
+test_that("share handles single-element matrix and array", {
+    # 1x1 matrix
+    mat <- matrix(42, nrow = 1, ncol = 1)
+    shared <- share(mat)
+    recovered <- fetch(shared)
+    expect_identical(mat, recovered)
+    close(shared)
+
+    # 1x1x1 array
+    arr <- array(42, dim = c(1, 1, 1))
+    shared <- share(arr)
+    recovered <- fetch(shared)
+    expect_identical(arr, recovered)
+    close(shared)
+})
+
+test_that("share handles empty data.frame", {
+    # Zero-row data.frame
+    df <- data.frame(a = integer(0), b = character(0), stringsAsFactors = FALSE)
+    shared <- share(df)
+    recovered <- fetch(shared)
+    expect_identical(df, recovered)
+    close(shared)
+
+    # Zero-column data.frame
+    df <- data.frame()
+    shared <- share(df)
+    recovered <- fetch(shared)
+    expect_identical(df, recovered)
+    close(shared)
+})
+
+test_that("share handles empty list", {
+    lst <- list()
+    shared <- share(lst)
+    recovered <- fetch(shared)
+    expect_identical(lst, recovered)
+    close(shared)
+})
+
 test_that("share handles NULL elements in lists", {
     lst <- list(a = 1, b = NULL, c = 3)
     shared <- share(lst)


### PR DESCRIPTION
…(sd-0jg)

Add comprehensive test coverage for edge cases:
- share(): zero-length vectors of all types (double, logical, character, raw)
- share(): single-element vectors, matrices, arrays
- share(): empty data.frames and lists
- buffer(): single-element dimensions and 1x1 matrices
- shard_map(): single-element input, single shard, block_size=n