### PR TITLE
fix: replace materialize() hack with explicit DATAPTR via C function …

### DIFF
--- a/R/altrep.R
+++ b/R/altrep.R
@@ -254,27 +254,3 @@ as_shared <- function(x, readonly = TRUE, backing = "auto") {
     shared_vector(seg, type = type, offset = 0, length = length(x),
                   readonly = readonly)
 }
-
-#' Materialize a shared vector to a standard R vector
-#'
-#' Creates a copy of the shared data as a standard R vector.
-#' This is useful when you need to modify the data or when
-#' passing to functions that don't work well with ALTREP.
-#'
-#' @param x A shard ALTREP vector
-#' @return A standard R vector with the same data
-#' @export
-#' @examples
-#' \dontrun{
-#' x <- as_shared(1:100)
-#' y <- materialize(x)  # Standard vector copy
-#' is_shared_vector(y)  # FALSE
-#' }
-materialize <- function(x) {
-    if (!is_shared_vector(x)) {
-        stop("x must be a shard ALTREP vector")
-    }
-
-    # Force a deep copy
-    x + 0L * x[1]  # Triggers coercion
-}

--- a/R/share.R
+++ b/R/share.R
@@ -209,6 +209,10 @@ materialize.shard_shared <- function(x) {
 
 #' @export
 materialize.default <- function(x) {
+    # Handle raw ALTREP shared vectors (which have no special class)
+    if (is_shared_vector(x)) {
+        return(.Call("C_shard_altrep_materialize", x, PACKAGE = "shard"))
+    }
     x
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -34,6 +34,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"C_is_shard_altrep",                (DL_FUNC) &C_is_shard_altrep,                1},
     {"C_shard_altrep_segment",           (DL_FUNC) &C_shard_altrep_segment,           1},
     {"C_shard_altrep_reset_diagnostics", (DL_FUNC) &C_shard_altrep_reset_diagnostics, 1},
+    {"C_shard_altrep_materialize",       (DL_FUNC) &C_shard_altrep_materialize,       1},
     {NULL, NULL, 0}
 };
 

--- a/src/shard_altrep.c
+++ b/src/shard_altrep.c
@@ -695,3 +695,31 @@ SEXP C_shard_altrep_reset_diagnostics(SEXP x) {
 
     return R_NilValue;
 }
+
+/* Materialize: copy shared memory data to a standard R vector */
+SEXP C_shard_altrep_materialize(SEXP x) {
+    if (!ALTREP(x)) {
+        error("x must be a shard ALTREP vector");
+    }
+
+    shard_altrep_info_t *info = get_info(x);
+    if (!info) {
+        error("Invalid shard ALTREP vector");
+    }
+
+    /* Track materialization for diagnostics */
+    info->materialize_calls++;
+
+    /* Allocate standard R vector */
+    R_xlen_t n = info->length;
+    SEXP result = PROTECT(allocVector(info->sexp_type, n));
+
+    /* Copy data from shared memory to the new vector */
+    void *src = get_data_ptr(x, info);
+    if (src && n > 0) {
+        memcpy(DATAPTR(result), src, n * info->element_size);
+    }
+
+    UNPROTECT(1);
+    return result;
+}

--- a/src/shard_altrep.h
+++ b/src/shard_altrep.h
@@ -81,4 +81,15 @@ attribute_visible SEXP C_shard_altrep_segment(SEXP x);
  */
 attribute_visible SEXP C_shard_altrep_reset_diagnostics(SEXP x);
 
+/*
+ * Materialize a shared vector to a standard R vector
+ *
+ * Creates a copy of the shared data as a standard R vector.
+ * The result is not backed by shared memory.
+ *
+ * @param x         ALTREP shared vector
+ * @return          Standard R vector with copied data
+ */
+attribute_visible SEXP C_shard_altrep_materialize(SEXP x);
+
 #endif /* SHARD_ALTREP_H */


### PR DESCRIPTION
…(sd-j7q)

The previous materialize() implementation used a fragile hack (x + 0L * x[1]) to force materialization. This replaces it with:

- New C function C_shard_altrep_materialize() that explicitly allocates a standard R vector and copies data using DATAPTR/memcpy
- Updated materialize.default() to detect raw ALTREP shared vectors and call the C function (needed because shared_vector has class "integer", not a special class for S3 dispatch)
- Removed the old hacky materialize() from altrep.R

Acceptance criteria verified:
- materialize(shared_vec) returns a standard R vector
- is_shared_vector(materialize(x)) returns FALSE
- Works for all supported types (integer, double, logical, raw)