### PR TITLE
fix(altrep): use explicit C-level materialize instead of coercion hack

### DIFF
--- a/R/altrep.R
+++ b/R/altrep.R
@@ -255,26 +255,3 @@ as_shared <- function(x, readonly = TRUE, backing = "auto") {
                   readonly = readonly)
 }
 
-#' Materialize a shared vector to a standard R vector
-#'
-#' Creates a copy of the shared data as a standard R vector.
-#' This is useful when you need to modify the data or when
-#' passing to functions that don't work well with ALTREP.
-#'
-#' @param x A shard ALTREP vector
-#' @return A standard R vector with the same data
-#' @export
-#' @examples
-#' \dontrun{
-#' x <- as_shared(1:100)
-#' y <- materialize(x)  # Standard vector copy
-#' is_shared_vector(y)  # FALSE
-#' }
-materialize <- function(x) {
-    if (!is_shared_vector(x)) {
-        stop("x must be a shard ALTREP vector")
-    }
-
-    # Force a deep copy
-    x + 0L * x[1]  # Triggers coercion
-}

--- a/R/share.R
+++ b/R/share.R
@@ -209,6 +209,10 @@ materialize.shard_shared <- function(x) {
 
 #' @export
 materialize.default <- function(x) {
+    # Handle shard ALTREP vectors (from shared_vector/as_shared)
+    if (is_shared_vector(x)) {
+        return(.Call("C_shard_altrep_materialize", x, PACKAGE = "shard"))
+    }
     x
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -34,6 +34,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"C_is_shard_altrep",                (DL_FUNC) &C_is_shard_altrep,                1},
     {"C_shard_altrep_segment",           (DL_FUNC) &C_shard_altrep_segment,           1},
     {"C_shard_altrep_reset_diagnostics", (DL_FUNC) &C_shard_altrep_reset_diagnostics, 1},
+    {"C_shard_altrep_materialize",       (DL_FUNC) &C_shard_altrep_materialize,       1},
     {NULL, NULL, 0}
 };
 

--- a/src/shard_altrep.h
+++ b/src/shard_altrep.h
@@ -81,4 +81,15 @@ attribute_visible SEXP C_shard_altrep_segment(SEXP x);
  */
 attribute_visible SEXP C_shard_altrep_reset_diagnostics(SEXP x);
 
+/*
+ * Materialize an ALTREP shared vector to a standard R vector
+ *
+ * Creates a copy of the shared data as a standard R vector.
+ * Increments the materialize_calls counter.
+ *
+ * @param x         ALTREP shared vector
+ * @return          Standard R vector with copied data
+ */
+attribute_visible SEXP C_shard_altrep_materialize(SEXP x);
+
 #endif /* SHARD_ALTREP_H */


### PR DESCRIPTION
Replace fragile `x + 0L * x[1]` hack with proper C_shard_altrep_materialize function that uses allocVector() and memcpy(DATAPTR(result), src, ...).

The fix properly integrates with the S3 generic materialize() by updating materialize.default() to check is_shared_vector() and call the C function.

Closes: sd-j7q