### PR TITLE
feat: implement share() - shared immutable memory segments via mmap/s…

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -163,13 +163,21 @@ fetch <- function(x, ...) {
 
 #' @export
 fetch.shard_shared <- function(x, ...) {
-    # If we have a valid segment pointer, read directly
+    # Try using existing segment pointer (main process scenario)
+    # Wrap in tryCatch because pointer becomes invalid after serialization to workers
     if (!is.null(x$segment) && inherits(x$segment, "shard_segment")) {
-        raw_data <- segment_read(x$segment, offset = 0, size = x$size)
-        return(unserialize(raw_data))
+        result <- tryCatch({
+            raw_data <- segment_read(x$segment, offset = 0, size = x$size)
+            unserialize(raw_data)
+        }, error = function(e) NULL)
+
+        if (!is.null(result)) {
+            return(result)
+        }
+        # Pointer was invalid (e.g., in worker process), fall through to reopen
     }
 
-    # Otherwise, open by path (worker process scenario)
+    # Open by path (worker process scenario)
     if (is.null(x$path)) {
         stop("Cannot fetch: no path available", call. = FALSE)
     }


### PR DESCRIPTION
…hm (sd-bu8)

Complete share() API for zero-copy shared objects:
- share(x): serialize object to shared memory segment
- fetch(shared): deserialize with automatic worker process fallback
- materialize(): alias for fetch()
- share_open(path): reopen existing shared segment
- shared_info(): get segment metadata
- is_shared(): type check

Key fix: fetch.shard_shared now handles serialized segment pointers gracefully in worker processes by catching invalid pointer errors and falling back to reopening by path.

All 594 tests passing including shard_map integration.